### PR TITLE
Enabling Runboat to use OCAs queue_job

### DIFF
--- a/src/runboat/kubefiles/ingress_odoo.yaml
+++ b/src/runboat/kubefiles/ingress_odoo.yaml
@@ -13,4 +13,11 @@ spec:
                 name: odoo
                 port:
                   number: 8069
+          - path: /websocket
+            pathType: Prefix
+            backend:
+              service:
+                name: odoo
+                port:
+                  number: 8072
   ingressClassName: nginx

--- a/src/runboat/kubefiles/runboat-clone-and-install.sh
+++ b/src/runboat/kubefiles/runboat-clone-and-install.sh
@@ -73,7 +73,11 @@ rm -rf mukit-modules/muk_web_enterprise_theme
 cp -r openg2p-registry/* ${ADDONS_DIR}/
 cat ${ADDONS_DIR}/test-requirements.txt >> ${ADDONS_DIR}/spp-test-requirements.txt
 cp -r openg2p-program/* ${ADDONS_DIR}/
-cat ${ADDONS_DIR}/test-requirements.txt >> ${ADDONS_DIR}/spp-test-requirements.txt
+# Do not install test requirements for openg2p-program as they are only references
+# to OpenSPP components from openspp-modules and installing them will overwrite the
+# module versions from the branch curl:ed on line 18.
+# cat ${ADDONS_DIR}/test-requirements.txt >> ${ADDONS_DIR}/spp-test-requirements.txt
+
 # MUK addons
 cp -r mukit-modules/* ${ADDONS_DIR}/
 echo "git+https://github.com/OpenSPP/openg2p-program@17.0-develop-openspp#subdirectory=g2p_programs" >> ${ADDONS_DIR}/spp-test-requirements.txt

--- a/src/runboat/kubefiles/runboat-initialize.sh
+++ b/src/runboat/kubefiles/runboat-initialize.sh
@@ -21,7 +21,7 @@ unbuffer $(which odoo || which openerp-server) \
   --data-dir=/mnt/data/odoo-data-dir \
   --db-template=template1 \
   -d ${PGDATABASE}-baseonly \
-  -i base \
+  -i base,queue_job \
   --stop-after-init
 
 # Try to install all addons, but do not fail in case of error, to let the build start

--- a/src/runboat/kubefiles/runboat-initialize.sh
+++ b/src/runboat/kubefiles/runboat-initialize.sh
@@ -16,7 +16,7 @@ dropdb --if-exists ${PGDATABASE}-baseonly
 
 ADDONS=$(manifestoo --select-addons-dir ${ADDONS_DIR} --select-include "${INCLUDE}" --select-exclude "${EXCLUDE}" list --separator=,)
 
-# Create the baseonly database if installation failed.
+# Create the baseonly database with queue support
 unbuffer $(which odoo || which openerp-server) \
   --data-dir=/mnt/data/odoo-data-dir \
   --db-template=template1 \

--- a/src/runboat/kubefiles/runboat-start.sh
+++ b/src/runboat/kubefiles/runboat-start.sh
@@ -24,6 +24,8 @@ echo "addons_path=${ADDONS_PATH},${ADDONS_DIR}" >> ${ODOO_RC}
 echo "without_demo = all" >> ${ODOO_RC}
 echo "workers = 2" >> ${ODOO_RC}
 echo "server_wide_modules = web,queue_job,base" >> ${ODOO_RC}
+echo "[queue_job]" >> ${ODOO_RC}
+echo "channels = root:2" >> ${ODOO_RC}
 cat ${ODOO_RC}
 
 # Install 'deb' external dependencies of all Odoo addons found in path.

--- a/src/runboat/kubefiles/runboat-start.sh
+++ b/src/runboat/kubefiles/runboat-start.sh
@@ -21,6 +21,9 @@ echo "admin_passwd=$(python3 -c 'import secrets; print(secrets.token_hex())')" >
 # but $ODOO_RC is not on a persistent volume, so it is lost when we
 # start in another container).
 echo "addons_path=${ADDONS_PATH},${ADDONS_DIR}" >> ${ODOO_RC}
+echo "without_demo = all" >> ${ODOO_RC}
+echo "workers = 2" >> ${ODOO_RC}
+echo "server_wide_modules = web,queue_job,base" >> ${ODOO_RC}
 cat ${ODOO_RC}
 
 # Install 'deb' external dependencies of all Odoo addons found in path.

--- a/src/runboat/kubefiles/runboat-start.sh
+++ b/src/runboat/kubefiles/runboat-start.sh
@@ -43,7 +43,14 @@ oca_wait_for_postgres
 # --db_user is necessary for Odoo <= 10
 unbuffer $(which odoo || which openerp-server) \
   --data-dir=/mnt/data/odoo-data-dir \
-  --db-filter=^${PGDATABASE} \
+  --database=${PGDATABASE}-baseonly \
   --db_user=${PGUSER} \
   --smtp=localhost \
   --smtp-port=1025
+
+# unbuffer $(which odoo || which openerp-server) \
+#   --data-dir=/mnt/data/odoo-data-dir \
+#   --db-filter=^${PGDATABASE} \
+#   --db_user=${PGUSER} \
+#  --smtp=localhost \
+#  --smtp-port=1025


### PR DESCRIPTION
This PR makes the necessary changes to support OCA:s `queue_job` on Runboat, which is required for multiple parts of OpenSPP.