### PR TITLE
Locking the odoo fastapi addon to the OpenSPP fork version

### DIFF
--- a/src/runboat/kubefiles/runboat-clone-and-install.sh
+++ b/src/runboat/kubefiles/runboat-clone-and-install.sh
@@ -81,7 +81,7 @@ cp -r openg2p-program/* ${ADDONS_DIR}/
 # MUK addons
 cp -r mukit-modules/* ${ADDONS_DIR}/
 echo "git+https://github.com/OpenSPP/openg2p-program@17.0-develop-openspp#subdirectory=g2p_programs" >> ${ADDONS_DIR}/spp-test-requirements.txt
-# wecho "git+https://github.com/OpenSPP/openg2p-rest-framework@17.0#subdirectory=fastapi" >> ${ADDONS_DIR}/spp-test-requirements.txt
+echo "git+https://github.com/OpenSPP/openg2p-rest-framework@17.0#subdirectory=fastapi" >> ${ADDONS_DIR}/spp-test-requirements.txt
 echo "git+https://github.com/OpenSPP/openg2p-rest-framework@17.0#subdirectory=extendable" >> ${ADDONS_DIR}/spp-test-requirements.txt
 echo "git+https://github.com/OpenSPP/openg2p-rest-framework@17.0#subdirectory=extendable_fastapi" >> ${ADDONS_DIR}/spp-test-requirements.txt
 echo "odoo-test-helper" >> ${ADDONS_DIR}/spp-test-requirements.txt


### PR DESCRIPTION
Bringing back the forked Odoo Addon "Fastapi" as the OCA version has diverged and is no longer compatible with our other dependencies.
